### PR TITLE
Making Docker future-proof

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Phase 1: Build
-FROM openjdk:21-oracle AS build
+FROM eclipse-temurin:21-jdk-alpine AS build
 
 # Create and copy app files
 RUN mkdir /app
@@ -12,13 +12,24 @@ WORKDIR /app
 RUN chmod +x ./mvnw
 
 # Build the application
-RUN ./mvnw clean package -DskipTests
+RUN ./mvnw clean package -DskipTests --activate-profiles docker
 
 # Phase 2: Runtime
-FROM openjdk:21-oracle
+FROM eclipse-temurin:21-jre-alpine
+
+# Set work directory
+WORKDIR /opt/pg
+
+# Create a group and user for better security
+RUN addgroup -S pg && \
+    adduser -S -G pg pg && \
+    chown -R pg:pg /opt/pg
 
 # Copy the JAR fromRequest the build stage
-COPY --from=build /app/target/TH1-0.0.1-SNAPSHOT.jar app.jar
+COPY --from=build /app/target/th1.jar app.jar
+
+# Change to 'pg' user
+USER pg
 
 # Run the application
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,24 +6,37 @@ services:
       - "8080:8080"
     networks:
       - server-side
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/example
+      SPRING_DATASOURCE_USERNAME: example
+      SPRING_DATASOURCE_PASSWORD: example
+      MINIO_URL: http://minio:9000
+      MINIO_ACCESS_NAME: minioadmin
+      MINIO_ACCESS_SECRET: minioadmin
     depends_on:
-      - db
+      db:
+          condition: service_healthy
+      minio:
+          condition: service_healthy
 
   db:
-    image: postgres
+    image: postgres:17-alpine
     ports:
       - "5432:5432"
     environment:
       POSTGRES_PASSWORD: example
       POSTGRES_USER: example
       POSTGRES_DB: example
+      PGUSER: example
     networks:
       - server-side
     volumes:
       - db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
 
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2025-01-20T14-49-07Z
     ports:
       - "9000:9000"
       - "9001:9001"
@@ -35,6 +48,8 @@ services:
     volumes:
       - minio-data:/data
     command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
 
 networks:
   server-side:

--- a/pom.xml
+++ b/pom.xml
@@ -235,4 +235,13 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>docker</id>
+            <build>
+                <finalName>th1</finalName>
+            </build>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
- Die openjdk docker images sind deprecated -> Wechsel zu Eclipse Temurin
- Build phase ->  JDK
- Runtime phase -> JRE
- Runtime user ->  Einführung eines Nutzer pg zum ausführen der Binary ->  Beste Practice (nicht als root ausführen)
- Healthtests für DB und ObjectStorage -> Starte Backend, wenn Abhängigkeiten wirklich laufen
- Compose mit ENV ergänzt, damit auf andere Container zugegriffen wird.
- maven Profil "docker" -> Mit diesem Profil heißt die jar am Ende immer th1 ->  Damit sind die Versionen für das Packaging irrelevant.