### PR TITLE
Rework API Validation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -71,6 +71,7 @@ components:
 
     structure:
       type: object
+      x-class-extra-annotation: "@de.uol.pgdoener.th1.api.validation.ValidStructure"
       required:
         - converterType
       properties:
@@ -131,6 +132,7 @@ components:
 
     converterType:
       type: string
+      x-field-extra-annotation: "@de.uol.pgdoener.th1.api.validation.ValidConverterType"
       enum:
         - REMOVE_GROUPED_HEADER
         - FILL_EMPTY_CELLS

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,8 @@
                             </supportingFilesToGenerate>
                             <modelNameSuffix>Dto</modelNameSuffix>
                             <configOptions>
+                                <configPackage>de.uol.pgdoener.th1.config</configPackage>
+                                <enumUnknownDefaultCase>true</enumUnknownDefaultCase>
                                 <useSpringBoot3>true</useSpringBoot3>
                                 <delegatePattern>true</delegatePattern>
                                 <booleanGetterPrefix>is</booleanGetterPrefix>

--- a/src/main/java/de/uol/pgdoener/th1/Th1Application.java
+++ b/src/main/java/de/uol/pgdoener/th1/Th1Application.java
@@ -1,10 +1,9 @@
 package de.uol.pgdoener.th1;
 
-import org.openapitools.configuration.SpringDocConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication(scanBasePackageClasses = {Th1Application.class, SpringDocConfiguration.class})
+@SpringBootApplication
 public class Th1Application {
     public static void main(String[] args) {
         //System.out.println(org.hibernate.Version.getVersionString());

--- a/src/main/java/de/uol/pgdoener/th1/api/validation/ValidConverterType.java
+++ b/src/main/java/de/uol/pgdoener/th1/api/validation/ValidConverterType.java
@@ -1,0 +1,25 @@
+package de.uol.pgdoener.th1.api.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(RUNTIME)
+@Target(FIELD)
+@Constraint(validatedBy = ValidConverterTypeValidator.class)
+public @interface ValidConverterType {
+
+    String message() default "invalid converterType";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/de/uol/pgdoener/th1/api/validation/ValidConverterTypeValidator.java
+++ b/src/main/java/de/uol/pgdoener/th1/api/validation/ValidConverterTypeValidator.java
@@ -1,0 +1,17 @@
+package de.uol.pgdoener.th1.api.validation;
+
+import de.uol.pgdoener.th1.business.dto.ConverterTypeDto;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class ValidConverterTypeValidator implements ConstraintValidator<ValidConverterType, ConverterTypeDto> {
+
+    @Override
+    public boolean isValid(ConverterTypeDto value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return false;
+        }
+        return value != ConverterTypeDto.UNKNOWN_DEFAULT_OPEN_API;
+    }
+
+}

--- a/src/main/java/de/uol/pgdoener/th1/api/validation/ValidStructure.java
+++ b/src/main/java/de/uol/pgdoener/th1/api/validation/ValidStructure.java
@@ -1,0 +1,23 @@
+package de.uol.pgdoener.th1.api.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+
+@Constraint(validatedBy = ValidStructureValidator.class)
+@Target({TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidStructure {
+
+    String message() default "Invalid structure configuration";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/de/uol/pgdoener/th1/api/validation/ValidStructureValidator.java
+++ b/src/main/java/de/uol/pgdoener/th1/api/validation/ValidStructureValidator.java
@@ -1,0 +1,28 @@
+package de.uol.pgdoener.th1.api.validation;
+
+import de.uol.pgdoener.th1.business.dto.ConverterTypeDto;
+import de.uol.pgdoener.th1.business.dto.StructureDto;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class ValidStructureValidator implements ConstraintValidator<ValidStructure, StructureDto> {
+
+    @SuppressWarnings("DuplicateBranchesInSwitch")
+    @Override
+    public boolean isValid(StructureDto structure, ConstraintValidatorContext context) {
+        if (structure == null) {
+            return false;
+        }
+        ConverterTypeDto converterType = structure.getConverterType();
+
+        return switch (converterType) {
+            case REMOVE_GROUPED_HEADER -> structure.getStartRow().isPresent() && structure.getEndRow().isPresent()
+                    && structure.getStartColumn().isPresent() && structure.getEndColumn().isPresent();
+            case FILL_EMPTY_CELLS -> structure.getRowIndex() != null && !structure.getRowIndex().isEmpty();
+            case REMOVE_COLUMN_BY_INDEX -> structure.getColumnIndex() != null && !structure.getColumnIndex().isEmpty();
+            case REMOVE_ROW_BY_INDEX -> structure.getRowIndex() != null && !structure.getRowIndex().isEmpty();
+            default -> false;
+        };
+    }
+
+}

--- a/src/main/java/de/uol/pgdoener/th1/api/validation/ValidStructureValidator.java
+++ b/src/main/java/de/uol/pgdoener/th1/api/validation/ValidStructureValidator.java
@@ -17,7 +17,9 @@ public class ValidStructureValidator implements ConstraintValidator<ValidStructu
 
         return switch (converterType) {
             case REMOVE_GROUPED_HEADER -> structure.getStartRow().isPresent() && structure.getEndRow().isPresent()
-                    && structure.getStartColumn().isPresent() && structure.getEndColumn().isPresent();
+                    && structure.getStartColumn().isPresent() && structure.getEndColumn().isPresent()
+                    && structure.getRowIndex() != null && !structure.getRowIndex().isEmpty()
+                    && structure.getColumnIndex() != null && !structure.getColumnIndex().isEmpty();
             case FILL_EMPTY_CELLS -> structure.getRowIndex() != null && !structure.getRowIndex().isEmpty();
             case REMOVE_COLUMN_BY_INDEX -> structure.getColumnIndex() != null && !structure.getColumnIndex().isEmpty();
             case REMOVE_ROW_BY_INDEX -> structure.getRowIndex() != null && !structure.getRowIndex().isEmpty();

--- a/src/main/java/de/uol/pgdoener/th1/business/mapper/StructureMapper.java
+++ b/src/main/java/de/uol/pgdoener/th1/business/mapper/StructureMapper.java
@@ -78,6 +78,8 @@ public abstract class StructureMapper {
                     throw new IllegalArgumentException("Rows missing");
                 }
                 yield new RemoveRowByIndexStructure(structureDto.getRowIndex().toArray(new Integer[0]));
+            case UNKNOWN_DEFAULT_OPEN_API: // This should never happen
+                throw new IllegalArgumentException("Unknown converterType");
         };
     }
 


### PR DESCRIPTION
- Added validators for the `StructureDto` and the `ConverterTypeDto`
- Added a default entry for enums, which is used when an invalid value is provided
- Added the annotations to the models for validation