### PR TITLE
Adding restart Policy to docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,7 @@ COPY --from=build /app/target/th1.jar app.jar
 # Change to 'pg' user
 USER pg
 
+EXPOSE 8080
+
 # Run the application
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -40,43 +40,50 @@ While the project is running, you can access the Swagger UI at http://localhost:
 > **Note:** If you are using an IDE, you might have to set `target/generated-sources/openapi/src/main/java` as a
 > generated sources root to avoid compilation errors.
 
-
 ## Docker
 
-In order to run and test the application locally, you need to set up a database for the app to connect to. This might be 
+In order to run and test the application locally, you need to set up a database for the app to connect to. This might be
 done using docker.
 
-In the `docker` directory, you will find a `docker-compose.yml` file which defines all necessary variables to set start 
-a postgres database. Make sure, Docker and Docker compose are installed. Also, make sure to duplicate the `*.env.sample` 
-files and remove the `.sample` ending. The env files are filled with the necessary environment variables for the application
-to start. However, it is **strongly** recommended to change the variables values to avoid any security issues even in 
+In the `docker` directory, you will find a `docker-compose.yaml` file which defines all necessary variables to set start
+a postgres database. Make sure, Docker and Docker compose are installed. Also, make sure to duplicate the `*.env.sample`
+files and remove the `.sample` ending. The env files are filled with the necessary environment variables for the
+application
+to start. However, it is **strongly** recommended to change the variables values to avoid any security issues even in
 the dev environment.
 
 Then, run the following command in the root directory of the project:
 
+> **NOTE:** The docker commands will be much simpler if you `cd` into the `docker` directory. This will allow you to not
+> pass the `-f docker/docker-compose.yaml` flag to the docker commands.
+
 ```bash
-docker compose -f docker/docker-compose.yml up -d db && docker compose logs -f
+docker compose -f docker/docker-compose.yaml up -d db && docker compose -f docker/docker-compose.yaml logs -f
 ```
 
 This will pull (if not already done) and start a postgres database in a docker container. The logs will be shown in the
-console. You might at any time press CTRL+C to stop the logs from showing. The database will keep running in the background.
+console. You might at any time press CTRL+C to stop the logs from showing. The database will keep running in the
+background.
 
 ### Testing whole docker stack
 
-To test the whole application inside docker, prepare the `*.env` files as described above. Then run the following command:
+To test the whole application inside docker, prepare the `*.env` files as described above. Then run the following
+command:
 
 ```bash
-docker compose -f docker/docker-compose.yml up -d --build && docker compose logs -f backend
+docker compose -f docker/docker-compose.yaml up -d --build && docker compose -f docker/docker-compose.yaml logs -f backend
 ```
 
-This will build the th1 application from the current state of the repository and start it in a docker container. The logs
-will be shown in the console. You might at any time press CTRL+C to stop the logs from showing. The application will keep
+This will build the th1 application from the current state of the repository and start it in a docker container. The
+logs
+will be shown in the console. You might at any time press CTRL+C to stop the logs from showing. The application will
+keep
 running in the background.
 
 To stop the application, run the following command:
 
 ```bash
-docker compose down
+docker compose -f docker/docker-compose.yaml down
 ```
 
 > **Note:** Please consult the wiki page for further information about the docker setup.

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -14,11 +14,12 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    restart: unless-stopped
 
   db:
     image: postgres:17-alpine
-    ports:
-      - "5432:5432"
+    # ports:
+    #  - "5432:5432"
     env_file:
       - db.env
     networks:
@@ -27,6 +28,7 @@ services:
       - db-data:/var/lib/postgresql/data
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready" ]
+    restart: unless-stopped
 
 networks:
   server-side:


### PR DESCRIPTION
Also:
- Adding EXPOSE statement to Dockerfile for documentation purposes of the exposed port by the application.
- Removed the explicit mapping of the database in order to not expose the db port to the whole world.