### PR TITLE
Update deploy script

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -17,11 +17,12 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     steps:
-      - name: Execute deploy script on dev server
-        uses: appleboy/ssh-action@v1.2.2
-        with:
-          host: ${{ secrets.DEPLOY_HOST }}
-          username: ${{ secrets.DEPLOY_USERNAME }}
-          key: ${{ secrets.DEPLOY_KEY }}
-          port: ${{ secrets.DEPLOY_PORT }}
-          script: ${{ secrets.DEPLOY_SCRIPT }}
+      - name: Perform deploy requests
+        run: |
+          data=$(curl -s ${{ secrets.API_HOST }}/api/stacks/${{ secrets.STACK_ID }}/file \
+            -H "X-API-KEY: ${{ secrets.API_KEY }}"  | jq '.StackFileContent')
+          wrapped=$(jq -n --argjson data "$data" '{Env:[],id:${{ secrets.STACK_ID }},Prune:false,PullImage:true,StackFileContent: $data}')
+          curl -X PUT ${{ secrets.API_HOST }}/api/stacks/${{ secrets.STACK_ID }}?endpointId=${{ secrets.ENDPOINT_ID }} \
+            -H "Content-Type: application/json" \
+            -H "X-API-KEY: ${{ secrets.API_KEY }}" \
+            -d "$wrapped"


### PR DESCRIPTION
Using the new deployment setup, this PR updates the strategy of deployment reducing the whole workflow to two single api requests. No external action is required. 
The deployment process is separated in two steps:
1. request current setup from deployment
2. PUT current setup on server with request to repull `latest` images

This process works because before deployment the new image is created in the ghcr, which then can be pulled from the deployment environment.

You can find further information about the deployment process in the openProject Wiki