### PR TITLE
Revert "Bump org.springdoc:springdoc-openapi-starter-webmvc-ui from 2.8.6 to 2.8.8"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <java.version>21</java.version>
-        <springdoc.version>2.8.8</springdoc.version>
+        <springdoc.version>2.8.6</springdoc.version>
         <swagger-ui.version>5.3.1</swagger-ui.version>
         <lombok.mapstruct.version>0.2.0</lombok.mapstruct.version>
         <mapstruct.version>1.6.3</mapstruct.version>


### PR DESCRIPTION
Reverts uol-esis/TH1#124

Problem: Swagger UI was not working: 
```
2025-05-08T14:53:25.972+02:00 ERROR 245036 --- [TH1] [nio-8080-exec-8] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception

com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Java 8 optional type `java.util.Optional` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jdk8" to enable handling (through reference chain: io.swagger.v3.oas.models.OpenAPI["paths"]->io.swagger.v3.oas.models.Paths["/api/v1/converter/preview"]->io.swagger.v3.oas.models.PathItem["post"]->io.swagger.v3.oas.models.Operation["parameters"]->java.util.ArrayList[0]->io.swagger.v3.oas.models.parameters.Parameter["schema"]->io.swagger.v3.oas.models.media.JsonSchema["default"])
	at com.fasterxml.jackson.databind.exc.InvalidDefinitionException.from(InvalidDefinitionException.java:77) ~[jackson-databind-2.18.3.jar:2.18.3]
	at com.fasterxml.jackson.databind.SerializerProvider.reportBadDefinition(SerializerProvider.java:1340) ~[jackson-databind-2.18.3.jar:2.18.3]
	at com.fasterxml.jackson.databind.ser.impl.UnsupportedTypeSerializer.serialize(UnsupportedTypeSerializer.java:35) ~[jackson-databind-2.18.3.jar:2.18.3]
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:732) ~[jackson-databind-2.18.3.jar:2.18.3]
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:770) ~[jackson-databind-2.18.3.jar:2.18.3]
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:184) ~[jackson-databind-2.18.3.jar:2.18.3]
	at io.swagger.v3.core.jackson.Schema31Serializer.serialize(Schema31Serializer.java:42) ~[swagger-core-jakarta-2.2.30.jar:2.2.30]
	at io.swagger.v3.core.jackson.Schema31Serializer.serialize(Schema31Serializer.java:12) ~[swagger-core-jakarta-2.2.30.jar:2.2.30]
```