### PR TITLE
add MergeColumnsConverter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
                         </goals>
                         <configuration>
                             <inputSpec>
-                                https://raw.githubusercontent.com/uol-esis/TH1-OpenAPI/v1.9.3/openapi.yaml
+                                https://raw.githubusercontent.com/uol-esis/TH1-OpenAPI/b6cb5cbdc4a812ebca48931a2b4c292bb80d91d4/openapi.yaml
                             </inputSpec>
                             <generatorName>spring</generatorName>
                             <apiPackage>de.uol.pgdoener.th1.api</apiPackage>

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
                         </goals>
                         <configuration>
                             <inputSpec>
-                                https://raw.githubusercontent.com/uol-esis/TH1-OpenAPI/b6cb5cbdc4a812ebca48931a2b4c292bb80d91d4/openapi.yaml
+                                https://raw.githubusercontent.com/uol-esis/TH1-OpenAPI/v1.12.0/openapi.yaml
                             </inputSpec>
                             <generatorName>spring</generatorName>
                             <apiPackage>de.uol.pgdoener.th1.api</apiPackage>

--- a/src/main/java/de/uol/pgdoener/th1/business/infrastructure/converterchain/core/ConverterFactory.java
+++ b/src/main/java/de/uol/pgdoener/th1/business/infrastructure/converterchain/core/ConverterFactory.java
@@ -21,6 +21,7 @@ public abstract class ConverterFactory {
             case ReplaceEntriesStructureDto s -> new ReplaceEntriesConverter(s);
             case SplitRowStructureDto s -> new SplitRowConverter(s);
             case RemoveInvalidRowsStructureDto s -> new RemoveInvalidRowsConverter(s);
+            case MergeColumnsStructureDto s -> new MergeColumnsConverter(s);
         };
     }
 }

--- a/src/main/java/de/uol/pgdoener/th1/business/infrastructure/converterchain/core/converter/MergeColumnsConverter.java
+++ b/src/main/java/de/uol/pgdoener/th1/business/infrastructure/converterchain/core/converter/MergeColumnsConverter.java
@@ -14,6 +14,7 @@ public class MergeColumnsConverter extends Converter {
 
     private final MergeColumnsStructureDto structure;
 
+    // the precedenceOrder list should only be modified by the fillPrecedenceOrder method
     private List<Integer> precedenceOrder;
 
     @Override
@@ -66,6 +67,15 @@ public class MergeColumnsConverter extends Converter {
         precedenceOrder = Collections.unmodifiableList(po);
     }
 
+    /**
+     * Constructs a new row by merging the specified columns.
+     * The merged column has the lowest index in the precedence order.
+     * Entries are taken from the columns in the precedence order.
+     * The first valid entry is used.
+     *
+     * @param row the row to merge
+     * @return the new row with merged columns
+     */
     private String[] constructMergedRow(String[] row) {
         String[] newRow = new String[row.length - precedenceOrder.size() + 1];
         int newRowIndex = 0;

--- a/src/main/java/de/uol/pgdoener/th1/business/infrastructure/converterchain/core/converter/MergeColumnsConverter.java
+++ b/src/main/java/de/uol/pgdoener/th1/business/infrastructure/converterchain/core/converter/MergeColumnsConverter.java
@@ -1,0 +1,102 @@
+package de.uol.pgdoener.th1.business.infrastructure.converterchain.core.converter;
+
+import de.uol.pgdoener.th1.business.dto.MergeColumnsStructureDto;
+import de.uol.pgdoener.th1.business.infrastructure.converterchain.core.Converter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class MergeColumnsConverter extends Converter {
+
+    private final MergeColumnsStructureDto structure;
+
+    private List<Integer> precedenceOrder;
+
+    @Override
+    public String[][] handleRequest(@NonNull String[][] matrix) {
+        this.precedenceOrder = structure.getPrecedenceOrder();
+        validateInputs();
+        fillPrecedenceOrder();
+
+        // Merge columns row by row
+        for (int i = 0; i < matrix.length; i++) {
+            String[] row = matrix[i];
+            String[] newRow = constructMergedRow(row);
+            matrix[i] = newRow;
+        }
+
+        // Set the header name for the merged column
+        int mergedColumnIndex = mergedColumnIndex();
+        String headerName = structure.getHeaderName();
+        matrix[0][mergedColumnIndex] = headerName;
+
+        return super.handleRequest(matrix);
+    }
+
+
+    private void validateInputs() {
+        List<Integer> columns = structure.getColumnIndex();
+        if (columns.size() < 2) {
+            throwConverterException("At least two columns must be specified for merging.");
+        }
+        for (Integer index : precedenceOrder) {
+            if (!columns.contains(index)) {
+                throwConverterException("Precedence order must only contain columns that are specified for merging.");
+            }
+        }
+    }
+
+    /**
+     * If there are not all columns in the precedence order, append the rest in ascending order at the end.
+     * Also make the list unmodifiable to prevent further changes.
+     */
+    private void fillPrecedenceOrder() {
+        List<Integer> columns = new ArrayList<>(structure.getColumnIndex());
+        List<Integer> po = new ArrayList<>(precedenceOrder);
+        Collections.sort(columns);
+        for (Integer column : columns) {
+            if (!po.contains(column)) {
+                po.add(column);
+            }
+        }
+        precedenceOrder = Collections.unmodifiableList(po);
+    }
+
+    private String[] constructMergedRow(String[] row) {
+        String[] newRow = new String[row.length - precedenceOrder.size() + 1];
+        int newRowIndex = 0;
+        int mergedColumnIndex = mergedColumnIndex();
+
+        for (int i = 0; i < row.length; i++) {
+            if (i == mergedColumnIndex) {
+                for (Integer index : precedenceOrder) {
+                    String value = row[index];
+                    if (isValid(value)) {
+                        newRow[mergedColumnIndex] = value;
+                        break;
+                    }
+                }
+                newRowIndex++;
+            } else if (!precedenceOrder.contains(i)) {
+                newRow[newRowIndex] = row[i];
+                newRowIndex++;
+            }
+        }
+
+        return newRow;
+    }
+
+    private boolean isValid(String string) {
+        return string != null && !string.isBlank();
+    }
+
+    private int mergedColumnIndex() {
+        // There must be an index. This was checked before.
+        return precedenceOrder.stream().min(Integer::compareTo).orElseThrow();
+    }
+
+}

--- a/src/main/java/de/uol/pgdoener/th1/business/mapper/StructureMapper.java
+++ b/src/main/java/de/uol/pgdoener/th1/business/mapper/StructureMapper.java
@@ -90,6 +90,14 @@ public abstract class StructureMapper {
                     .delimiter(structure.getDelimiter())
                     .startRow(structure.getStartRow())
                     .endRow(structure.getEndRow());
+            case MergeColumnsStructure structure -> new MergeColumnsStructureDto(
+                    ConverterTypeDto.MERGE_COLUMNS,
+                    List.of(structure.getColumns()),
+                    structure.getHeaderName()
+            )
+                    .name(structure.getName())
+                    .description(structure.getDescription())
+                    .precedenceOrder(List.of(structure.getPrecedenceOrder()));
             default -> throw new IllegalStateException("Unexpected value: " + entity);
         };
     }
@@ -200,6 +208,17 @@ public abstract class StructureMapper {
                     structure.getThreshold().orElse(null),
                     structure.getBlackList().toArray(new String[0])
             );
+            case MergeColumnsStructureDto structure -> new MergeColumnsStructure(
+                    null, // ID wird von der Datenbank generiert
+                    position,
+                    tableStructureId,
+                    structure.getName().orElse(null),
+                    structure.getDescription().orElse(null),
+                    structure.getColumnIndex().toArray(new Integer[0]),
+                    structure.getHeaderName(),
+                    structure.getPrecedenceOrder().toArray(new Integer[0])
+            );
+            // no default needed, all cases are handled
         };
     }
 

--- a/src/main/java/de/uol/pgdoener/th1/data/entity/MergeColumnsStructure.java
+++ b/src/main/java/de/uol/pgdoener/th1/data/entity/MergeColumnsStructure.java
@@ -1,0 +1,35 @@
+package de.uol.pgdoener.th1.data.entity;
+
+import io.hypersistence.utils.hibernate.type.array.IntArrayType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Type;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MergeColumnsStructure extends Structure {
+
+    public MergeColumnsStructure(Long id, int position, Long tableStructureId, String name, String description,
+                                 Integer[] columns, String headerName, Integer[] precedenceOrder) {
+        super(id, position, tableStructureId, name, description);
+        this.columns = columns;
+        this.headerName = headerName;
+        this.precedenceOrder = precedenceOrder;
+    }
+
+    @Type(IntArrayType.class)
+    @Column(columnDefinition = "integer[]", nullable = true)
+    private Integer[] columns;
+
+    private String headerName;
+
+    @Type(IntArrayType.class)
+    @Column(columnDefinition = "integer[]", nullable = true)
+    private Integer[] precedenceOrder;
+
+}

--- a/src/test/java/de/uol/pgdoener/th1/business/infrastructure/converterchain/core/converter/MergeColumnsConverterTest.java
+++ b/src/test/java/de/uol/pgdoener/th1/business/infrastructure/converterchain/core/converter/MergeColumnsConverterTest.java
@@ -1,0 +1,232 @@
+package de.uol.pgdoener.th1.business.infrastructure.converterchain.core.converter;
+
+import de.uol.pgdoener.th1.business.dto.MergeColumnsStructureDto;
+import de.uol.pgdoener.th1.business.infrastructure.converterchain.core.ConverterException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MergeColumnsConverterTest {
+
+    @Test
+    void testHandleRequest() {
+        MergeColumnsStructureDto structure = new MergeColumnsStructureDto(
+                null,
+                List.of(0, 1),
+                "merged"
+        );
+        MergeColumnsConverter converter = new MergeColumnsConverter(structure);
+        String[][] matrix = new String[][]{
+                {"h1", "h2", "h3", "h4"},
+                {"w", "", "r", "d"},
+                {" ", "o", "r", "d"}
+        };
+
+        String[][] result = converter.handleRequest(matrix);
+
+        String[][] expected = new String[][]{
+                {"merged", "h3", "h4"},
+                {"w", "r", "d"},
+                {"o", "r", "d"}
+        };
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testHandleRequestWithEmptyMatrix() {
+        MergeColumnsStructureDto structure = new MergeColumnsStructureDto(
+                null,
+                List.of(0, 1),
+                "merged"
+        );
+        MergeColumnsConverter converter = new MergeColumnsConverter(structure);
+        String[][] matrix = new String[][]{};
+
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> converter.handleRequest(matrix));
+    }
+
+    @Test
+    void testHandleRequestWithPrecedenceOrder() {
+        MergeColumnsStructureDto structure = new MergeColumnsStructureDto(
+                null,
+                List.of(0, 1),
+                "merged"
+        )
+                .precedenceOrder(List.of(1, 0));
+        MergeColumnsConverter converter = new MergeColumnsConverter(structure);
+        String[][] matrix = new String[][]{
+                {"h1", "h2", "h3", "h4"},
+                {"w", "f", "r", "d"},
+                {" ", "o", "r", "d"}
+        };
+
+        String[][] result = converter.handleRequest(matrix);
+
+        String[][] expected = new String[][]{
+                {"merged", "h3", "h4"},
+                {"f", "r", "d"},
+                {"o", "r", "d"}
+        };
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testHandleRequestWithInvalidPrecedenceOrder() {
+        MergeColumnsStructureDto structure = new MergeColumnsStructureDto(
+                null,
+                List.of(0, 1),
+                "merged"
+        )
+                .precedenceOrder(List.of(2, 3));
+        MergeColumnsConverter converter = new MergeColumnsConverter(structure);
+        String[][] matrix = new String[][]{
+                {"h1", "h2", "h3", "h4"},
+                {"w", "f", "r", "d"},
+                {" ", "o", "r", "d"}
+        };
+
+        assertThrows(ConverterException.class, () -> converter.handleRequest(matrix));
+    }
+
+    @Test
+    void testHandleRequestWithInvalidColumnCount() {
+        MergeColumnsStructureDto structure = new MergeColumnsStructureDto(
+                null,
+                List.of(0),
+                "merged"
+        );
+        MergeColumnsConverter converter = new MergeColumnsConverter(structure);
+        String[][] matrix = new String[][]{
+                {"h1", "h2", "h3", "h4"},
+                {"w", "f", "r", "d"},
+                {" ", "o", "r", "d"}
+        };
+
+        assertThrows(ConverterException.class, () -> converter.handleRequest(matrix));
+    }
+
+    @Test
+    void testHandleRequestWithEmptyHeaderName() {
+        MergeColumnsStructureDto structure = new MergeColumnsStructureDto(
+                null,
+                List.of(0, 1),
+                ""
+        );
+        MergeColumnsConverter converter = new MergeColumnsConverter(structure);
+        String[][] matrix = new String[][]{
+                {"h1", "h2", "h3", "h4"},
+                {"w", "f", "r", "d"},
+                {" ", "o", "r", "d"}
+        };
+
+        String[][] result = converter.handleRequest(matrix);
+
+        String[][] expected = new String[][]{
+                {"", "h3", "h4"},
+                {"w", "r", "d"},
+                {"o", "r", "d"}
+        };
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testHandleRequestAtEndOfMatrix() {
+        MergeColumnsStructureDto structure = new MergeColumnsStructureDto(
+                null,
+                List.of(2, 3),
+                "merged"
+        );
+        MergeColumnsConverter converter = new MergeColumnsConverter(structure);
+        String[][] matrix = new String[][]{
+                {"h1", "h2", "h3", "h4"},
+                {"w", "f", "", "d"},
+                {"w", "o", "", "d"}
+        };
+
+        String[][] result = converter.handleRequest(matrix);
+
+        String[][] expected = new String[][]{
+                {"h1", "h2", "merged"},
+                {"w", "f", "d"},
+                {"w", "o", "d"}
+        };
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testHandleRequestSpreadOut() {
+        MergeColumnsStructureDto structure = new MergeColumnsStructureDto(
+                null,
+                List.of(0, 2),
+                "merged"
+        );
+        MergeColumnsConverter converter = new MergeColumnsConverter(structure);
+        String[][] matrix = new String[][]{
+                {"h1", "h2", "h3", "h4"},
+                {"w", "", "r", "d"},
+                {" ", "o", "r", "d"}
+        };
+
+        String[][] result = converter.handleRequest(matrix);
+
+        String[][] expected = new String[][]{
+                {"merged", "h2", "h4"},
+                {"w", "", "d"},
+                {"r", "o", "d"}
+        };
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testHandleRequestWithManyColumns() {
+        MergeColumnsStructureDto structure = new MergeColumnsStructureDto(
+                null,
+                List.of(0, 1, 2, 3),
+                "merged"
+        );
+        MergeColumnsConverter converter = new MergeColumnsConverter(structure);
+        String[][] matrix = new String[][]{
+                {"h1", "h2", "h3", "h4"},
+                {"w", "", "r", "d"},
+                {" ", "o", "r", "d"}
+        };
+
+        String[][] result = converter.handleRequest(matrix);
+
+        String[][] expected = new String[][]{
+                {"merged"},
+                {"w"},
+                {"o"}
+        };
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testHandleRequestWithIncompletePrecedenceOrder() {
+        MergeColumnsStructureDto structure = new MergeColumnsStructureDto(
+                null,
+                List.of(0, 1),
+                "merged"
+        )
+                .precedenceOrder(List.of(1));
+        MergeColumnsConverter converter = new MergeColumnsConverter(structure);
+        String[][] matrix = new String[][]{
+                {"h1", "h2", "h3", "h4"},
+                {"w", "", "r", "d"},
+                {" ", "o", "r", "d"}
+        };
+
+        String[][] result = converter.handleRequest(matrix);
+
+        String[][] expected = new String[][]{
+                {"merged", "h3", "h4"},
+                {"w", "r", "d"},
+                {"o", "r", "d"}
+        };
+        assertArrayEquals(expected, result);
+    }
+
+}


### PR DESCRIPTION
Adds the `MergeColumnsConverter` which can be used to merge columns where only one column contains a valid entry for any given row.