### PR TITLE
Bugfix: Ignore first row in getValue method

### DIFF
--- a/src/main/java/de/uol/pgdoener/th1/business/service/datatable/helper/SqlHeaderBuilder.java
+++ b/src/main/java/de/uol/pgdoener/th1/business/service/datatable/helper/SqlHeaderBuilder.java
@@ -32,8 +32,8 @@ public class SqlHeaderBuilder {
     // private methods //
 
     private String getValue(int i, String[][] matrix) {
-        for (String[] row : matrix) {
-            String value = row[i];
+        for (int rowIndex = 1; rowIndex < matrix.length; rowIndex++) {
+            String value = matrix[rowIndex][i];
             if (value.equals("*")) continue;
             return value;
         }

--- a/src/main/java/de/uol/pgdoener/th1/business/service/datatable/helper/SqlValueBuilder.java
+++ b/src/main/java/de/uol/pgdoener/th1/business/service/datatable/helper/SqlValueBuilder.java
@@ -49,7 +49,7 @@ public class SqlValueBuilder {
     }
 
     private static Object formatValue(String value, String columnType) {
-        if ("-".equals(value)) {
+        if ("*".equals(value)) {
             return null;
         }
 


### PR DESCRIPTION
Do I also need to check for empty strings now, in case they are considered valid values in the matrix? I’m not quite sure anymore what issue was.