### PR TITLE
Setting a header name for merged columns.

### DIFF
--- a/src/main/java/de/uol/pgdoener/th1/domain/tablestructure/builder/TableStructureBuilder.java
+++ b/src/main/java/de/uol/pgdoener/th1/domain/tablestructure/builder/TableStructureBuilder.java
@@ -138,6 +138,7 @@ public class TableStructureBuilder {
         log.debug("Start buildMergeableColumnsStructure for column index");
         MergeColumnsStructureDto structure = new MergeColumnsStructureDto()
                 .converterType(ConverterTypeDto.MERGE_COLUMNS)
+                .headerName("undefined")
                 .columnIndex(report.getMergeables());
         log.debug("Finish buildMergeableColumnsStructure for column index");
         tableStructure.addStructuresItem(structure);


### PR DESCRIPTION
This field is normally required, but was not set while generating a table structure. This caused a NullPointerException in subsequent generation steps.