### PR TITLE
Remove uri from API_HOST

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
         OAUTH_REALM: th1
         OAUTH_CLIENT_ID: th1
     environment:
-      API_HOST: http://127.0.0.1:8080/api/v1/
+      API_HOST: http://127.0.0.1:8080
       METABASE_HOST: http://localhost:3000
     network_mode: host
 


### PR DESCRIPTION
When removing it, I get the list of table structures as expected.