### PR TITLE
Add noSecurity profile

### DIFF
--- a/src/main/java/de/uol/pgdoener/th1/config/NoSecurityConfig.java
+++ b/src/main/java/de/uol/pgdoener/th1/config/NoSecurityConfig.java
@@ -10,7 +10,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.web.SecurityFilterChain;
 
 @Slf4j
-@Profile("dev")
+@Profile("noSecurity")
 @Configuration
 public class NoSecurityConfig {
 

--- a/src/main/java/de/uol/pgdoener/th1/config/SecurityConfig.java
+++ b/src/main/java/de/uol/pgdoener/th1/config/SecurityConfig.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @Slf4j
-@Profile("!dev")
+@Profile("!noSecurity")
 @Configuration
 @EnableMethodSecurity
 @RequiredArgsConstructor


### PR DESCRIPTION
Security configurations may be disabled using the `noSecurity` profile. This is useful during local development and for public demonstrations