### PR TITLE
Adding Cors Filter to noSecurity Profile

### DIFF
--- a/src/main/java/de/uol/pgdoener/th1/config/NoSecurityConfig.java
+++ b/src/main/java/de/uol/pgdoener/th1/config/NoSecurityConfig.java
@@ -1,5 +1,7 @@
 package de.uol.pgdoener.th1.config;
 
+import de.uol.pgdoener.th1.autoconfigure.SecurityProperties;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,11 +10,19 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+import java.util.List;
 
 @Slf4j
 @Profile("noSecurity")
 @Configuration
+@RequiredArgsConstructor
 public class NoSecurityConfig {
+
+    private final SecurityProperties securityProperties;
 
     @Bean
     public SecurityFilterChain noSecurityFilterChain(HttpSecurity http) throws Exception {
@@ -22,5 +32,17 @@ public class NoSecurityConfig {
                         .anyRequest().permitAll()
                 );
         return http.build();
+    }
+
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(securityProperties.getAllowedOrigins());
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+        source.registerCorsConfiguration("/**", config);
+        return new CorsFilter(source);
     }
 }


### PR DESCRIPTION
When deployed the cors can now be configured as before. This is necessary for local development of the frontend as well as hosting frontend and backend on different servers.